### PR TITLE
test: fix failing test

### DIFF
--- a/tests/test.rs
+++ b/tests/test.rs
@@ -135,16 +135,16 @@ fn test_scan_matmul() {
 #[test]
 fn test_scan_addition(){
     let init = 0u64;
-    let op = |state: &mut u64, _x: &u64| {
-        *state += 1;
+    let op = |state: &mut u64, x: &u64| {
+        *state += x;
         Some(*state)
     };
-    let op_par = |state: &u64, _x: &u64| {
-        *state + 1
+    let op_par = |state: &u64, x: &u64| {
+        *state + x
     };
 
     for _i in 0..100{
-        let v = vec![0u64; 67];
+        let v = vec![1u64; 67];
         let scan_seq = v.iter().scan(init, op).collect::<Vec<u64>>();
         let scan_par = v.into_par_iter().scan(op_par, init).collect::<Vec<u64>>();
         assert_eq!(scan_seq, scan_par);


### PR DESCRIPTION
- the operation of the original test isn't associative
- the new test's operation is associative